### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/indexer",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.0](https://github.com/flow-build/indexer/releases/tag/v1.0.0)